### PR TITLE
Adding Makefile to docker template

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,0 +1,50 @@
+TAG := $(shell git rev-parse --short HEAD)
+DIR := $(shell pwd -L)
+GOPATH := ${GOPATH}
+ifeq ($(GOPATH),)
+	GOPATH := ${HOME}/go
+endif
+PROJECT_PATH := $(subst $(GOPATH)/src/,,$(DIR))
+
+dep:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go dep
+
+lint:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go lint
+
+test:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go test
+
+integration:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go integration
+
+coverage:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go coverage
+
+doc: ;
+
+build-dev: ;
+
+build: ;
+
+run:
+	docker-compose up --build --abort-on-container-exit
+
+deploy-dev: ;
+
+deploy: ;


### PR DESCRIPTION
To avoid Makefile conflicts between our open source and closed source repositories, I'm moving our open source Makefile into our open source Docker template, and out of the base repositories for our Go and Python repos. Since this makefile is designed to only work with a dockerized repository anyway, I think this change makes sense.